### PR TITLE
Fix cargo-dylint update

### DIFF
--- a/ci/docker/build/Dockerfile
+++ b/ci/docker/build/Dockerfile
@@ -3,5 +3,5 @@ FROM rust:1.77.0
 RUN set -eux; \
     apt-get update && \
     apt-get install -y pkg-config libssl-dev build-essential && \
-    cargo install --version 2.4.3 cargo-dylint dylint-link && \
+    cargo install --version 3.0.0 cargo-dylint dylint-link && \
     rustup update nightly-2024-01-25

--- a/ci/docker/release/Dockerfile
+++ b/ci/docker/release/Dockerfile
@@ -17,7 +17,7 @@ RUN set -eux; \
         # Libtelio dependencies
         quilt && \
     apt-get clean && \
-    cargo install --version 2.4.3 cargo-dylint dylint-link && \
+    cargo install --version 3.0.0 cargo-dylint dylint-link && \
     rustup update nightly-2024-01-25
 
 ENV NAGGER_PATH=/dist

--- a/existing_lints/Cargo.lock
+++ b/existing_lints/Cargo.lock
@@ -303,9 +303,9 @@ dependencies = [
 
 [[package]]
 name = "dylint"
-version = "2.6.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d6259cf4df09300534dcfa6a49918bb442327111e370c656b31f1c10ec08145"
+checksum = "927d37eecb249c058d2d6100fd86f47c9424d13796bcd02d2c81a6c1ed80067b"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -324,9 +324,9 @@ dependencies = [
 
 [[package]]
 name = "dylint_internal"
-version = "2.6.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9400420c9ffa71c6b1b75d84225a150e3428eb12159e5bf4f56285bd9eb1c095"
+checksum = "d4c32056fd5a610d2c9abc98155d395eb3ce61989c89e78e417241d06a5cc41b"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -338,15 +338,15 @@ dependencies = [
  "is-terminal",
  "log",
  "once_cell",
+ "regex",
  "rust-embed",
- "sedregex",
 ]
 
 [[package]]
 name = "dylint_linting"
-version = "2.6.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43fc05c7103dfadd497486bbbf941899888f4e19271da70b58f66385247230c2"
+checksum = "b952b4f93ea8df102105ea08a9fbcd92af9791c6cdb9a6f27bb2820816c26d5a"
 dependencies = [
  "cargo_metadata",
  "dylint_internal",
@@ -359,9 +359,9 @@ dependencies = [
 
 [[package]]
 name = "dylint_testing"
-version = "2.6.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "785fa52ac8fe5f1056a71955f4ebda3ca90c269ef28b172ad85a3901752d5fdf"
+checksum = "e493af8de71bd92c640c95782748be2f2b6ff3b976d7077edf917181ebdd534a"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -1204,15 +1204,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sedregex"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19411e23596093f03bbd11dc45603b6329bb4bfec77b9fd13e2b9fc9b02efe3e"
-dependencies = [
- "regex",
-]
 
 [[package]]
 name = "semver"

--- a/existing_lints/Cargo.toml
+++ b/existing_lints/Cargo.toml
@@ -5,3 +5,7 @@ members = [
     "large_futures",
     "index_access_check"
 ]
+
+[workspace.dependencies]
+dylint_linting = "3.0.0"
+dylint_testing = "3.0.0"

--- a/existing_lints/index_access_check/Cargo.toml
+++ b/existing_lints/index_access_check/Cargo.toml
@@ -9,8 +9,8 @@ crate-type = ["cdylib"]
 
 [dependencies]
 clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", tag = "rust-1.77.0"}
-dylint_linting = "3.0.0"
+dylint_linting.workspace = true
 if_chain = "1.0.2"
 
 [dev-dependencies]
-dylint_testing = "3.0.0"
+dylint_testing.workspace = true

--- a/existing_lints/index_access_check/Cargo.toml
+++ b/existing_lints/index_access_check/Cargo.toml
@@ -9,8 +9,8 @@ crate-type = ["cdylib"]
 
 [dependencies]
 clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", tag = "rust-1.77.0"}
-dylint_linting = "2.6.1"
+dylint_linting = "3.0.0"
 if_chain = "1.0.2"
 
 [dev-dependencies]
-dylint_testing = "2.6.1"
+dylint_testing = "3.0.0"

--- a/existing_lints/index_access_check/ui/index_access_check.stderr
+++ b/existing_lints/index_access_check/ui/index_access_check.stderr
@@ -1,14 +1,13 @@
-error: Use of Index [].
+warning: Use of Index [].
   --> $DIR/index_access_check.rs:11:19
    |
 LL |     let _result = get_array()[2];
    |                   ^^^^^^^^^^^^^^
    |
    = help: Consider implementing proper member (or range) access or using #[allow(index_access_check)] to suppress the warning.
-   = note: `-D index-access-check` implied by `-D warnings`
-   = help: to override `-D warnings` add `#[allow(index_access_check)]`
+   = note: `#[warn(index_access_check)]` on by default
 
-error: Use of Range [x..y].
+warning: Use of Range [x..y].
   --> $DIR/index_access_check.rs:21:20
    |
 LL |     let _result = &get_array()[1..2];
@@ -16,7 +15,7 @@ LL |     let _result = &get_array()[1..2];
    |
    = help: Consider implementing proper member (or range) access or using #[allow(index_access_check)] to suppress the warning.
 
-error: Use of Range [x..y].
+warning: Use of Range [x..y].
   --> $DIR/index_access_check.rs:26:20
    |
 LL |     let _result = &get_array()[1..];
@@ -24,7 +23,7 @@ LL |     let _result = &get_array()[1..];
    |
    = help: Consider implementing proper member (or range) access or using #[allow(index_access_check)] to suppress the warning.
 
-error: Use of Range [x..y].
+warning: Use of Range [x..y].
   --> $DIR/index_access_check.rs:31:20
    |
 LL |     let _result = &get_array()[..=2];
@@ -32,7 +31,7 @@ LL |     let _result = &get_array()[..=2];
    |
    = help: Consider implementing proper member (or range) access or using #[allow(index_access_check)] to suppress the warning.
 
-error: Use of Index [].
+warning: Use of Index [].
   --> $DIR/index_access_check.rs:49:19
    |
 LL |     let _result = get_array()[2];
@@ -40,5 +39,5 @@ LL |     let _result = get_array()[2];
    |
    = help: Consider implementing proper member (or range) access or using #[allow(index_access_check)] to suppress the warning.
 
-error: aborting due to 5 previous errors
+warning: 5 warnings emitted
 

--- a/existing_lints/large_futures/Cargo.toml
+++ b/existing_lints/large_futures/Cargo.toml
@@ -13,8 +13,8 @@ crate-type = ["cdylib"]
 
 [dependencies]
 clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", tag = "rust-1.77.0"}
-dylint_linting = "3.0.0"
+dylint_linting.workspace = true
 if_chain = "1.0.2"
 
 [dev-dependencies]
-dylint_testing = "3.0.0"
+dylint_testing.workspace = true

--- a/existing_lints/large_futures/Cargo.toml
+++ b/existing_lints/large_futures/Cargo.toml
@@ -13,8 +13,8 @@ crate-type = ["cdylib"]
 
 [dependencies]
 clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", tag = "rust-1.77.0"}
-dylint_linting = "2.6.1"
+dylint_linting = "3.0.0"
 if_chain = "1.0.2"
 
 [dev-dependencies]
-dylint_testing = "2.6.1"
+dylint_testing = "3.0.0"

--- a/existing_lints/large_futures/ui/large_futures.stderr
+++ b/existing_lints/large_futures/ui/large_futures.stderr
@@ -1,41 +1,40 @@
-error: large future with a size of 16385 bytes
+warning: large future with a size of 16385 bytes
   --> $DIR/large_futures.rs:11:9
    |
 LL |         big_fut([0u8; 1024 * 16]).await;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider `Box::pin` on it: `Box::pin(big_fut([0u8; 1024 * 16]))`
    |
-   = note: `-D large-futures` implied by `-D warnings`
-   = help: to override `-D warnings` add `#[allow(large_futures)]`
+   = note: `#[warn(large_futures)]` on by default
 
-error: large future with a size of 16386 bytes
+warning: large future with a size of 16386 bytes
   --> $DIR/large_futures.rs:13:5
    |
 LL |     f.await
    |     ^ help: consider `Box::pin` on it: `Box::pin(f)`
 
-error: large future with a size of 16387 bytes
+warning: large future with a size of 16387 bytes
   --> $DIR/large_futures.rs:17:9
    |
 LL |         wait().await;
    |         ^^^^^^ help: consider `Box::pin` on it: `Box::pin(wait())`
 
-error: large future with a size of 16387 bytes
+warning: large future with a size of 16387 bytes
   --> $DIR/large_futures.rs:21:13
    |
 LL |             wait().await;
    |             ^^^^^^ help: consider `Box::pin` on it: `Box::pin(wait())`
 
-error: large future with a size of 65540 bytes
+warning: large future with a size of 65540 bytes
   --> $DIR/large_futures.rs:28:5
    |
 LL |     foo().await;
    |     ^^^^^ help: consider `Box::pin` on it: `Box::pin(foo())`
 
-error: large future with a size of 49159 bytes
+warning: large future with a size of 49159 bytes
   --> $DIR/large_futures.rs:29:5
    |
 LL |     calls_fut(fut).await;
    |     ^^^^^^^^^^^^^^ help: consider `Box::pin` on it: `Box::pin(calls_fut(fut))`
 
-error: aborting due to 6 previous errors
+warning: 6 warnings emitted
 

--- a/existing_lints/mpsc_blocking_send/Cargo.toml
+++ b/existing_lints/mpsc_blocking_send/Cargo.toml
@@ -13,10 +13,10 @@ crate-type = ["cdylib"]
 
 [dependencies]
 clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", tag = "rust-1.77.0"}
-dylint_linting = "2.6.1"
+dylint_linting = "3.0.0"
 if_chain = "1.0.2"
 
 [dev-dependencies]
-dylint_testing = "2.6.1"
+dylint_testing = "3.0.0"
 tokio = { version = "1.20.1", features = ["full"]}
 reqwest = {version = "0.11", default-features = false, features = ["blocking"]}

--- a/existing_lints/mpsc_blocking_send/Cargo.toml
+++ b/existing_lints/mpsc_blocking_send/Cargo.toml
@@ -13,10 +13,10 @@ crate-type = ["cdylib"]
 
 [dependencies]
 clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", tag = "rust-1.77.0"}
-dylint_linting = "3.0.0"
+dylint_linting.workspace = true
 if_chain = "1.0.2"
 
 [dev-dependencies]
-dylint_testing = "3.0.0"
+dylint_testing.workspace = true
 tokio = { version = "1.20.1", features = ["full"]}
 reqwest = {version = "0.11", default-features = false, features = ["blocking"]}

--- a/existing_lints/mpsc_blocking_send/ui/mpsc_blocking_send.stderr
+++ b/existing_lints/mpsc_blocking_send/ui/mpsc_blocking_send.stderr
@@ -1,14 +1,13 @@
-error: Use of blocking mpsc::[Sync]Sender::send() variant, this might deadlock if used incorrectly
+warning: Use of blocking mpsc::[Sync]Sender::send() variant, this might deadlock if used incorrectly
   --> $DIR/mpsc_blocking_send.rs:13:13
    |
 LL |     let _ = chtx.send(msg.clone()).await;
    |             ^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: Consider using try_send() or wait_for_tx(). Alternatively use #[allow(mpsc_blocking_send)] to suppress the warning.
-   = note: `-D mpsc-blocking-send` implied by `-D warnings`
-   = help: to override `-D warnings` add `#[allow(mpsc_blocking_send)]`
+   = note: `#[warn(mpsc_blocking_send)]` on by default
 
-error: Use of blocking mpsc::[Sync]Sender::send() variant, this might deadlock if used incorrectly
+warning: Use of blocking mpsc::[Sync]Sender::send() variant, this might deadlock if used incorrectly
   --> $DIR/mpsc_blocking_send.rs:17:13
    |
 LL |     let _ = chtx.send(msg.clone());
@@ -16,7 +15,7 @@ LL |     let _ = chtx.send(msg.clone());
    |
    = help: Consider using try_send() or wait_for_tx(). Alternatively use #[allow(mpsc_blocking_send)] to suppress the warning.
 
-error: Use of blocking mpsc::[Sync]Sender::send() variant, this might deadlock if used incorrectly
+warning: Use of blocking mpsc::[Sync]Sender::send() variant, this might deadlock if used incorrectly
   --> $DIR/mpsc_blocking_send.rs:30:21
    |
 LL |             let _ = chtx.send(msg.clone()).await;
@@ -24,5 +23,5 @@ LL |             let _ = chtx.send(msg.clone()).await;
    |
    = help: Consider using try_send() or wait_for_tx(). Alternatively use #[allow(mpsc_blocking_send)] to suppress the warning.
 
-error: aborting due to 3 previous errors
+warning: 3 warnings emitted
 

--- a/existing_lints/unwrap_check/Cargo.toml
+++ b/existing_lints/unwrap_check/Cargo.toml
@@ -9,8 +9,8 @@ crate-type = ["cdylib"]
 
 [dependencies]
 clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", tag = "rust-1.77.0"}
-dylint_linting = "3.0.0"
+dylint_linting.workspace = true
 if_chain = "1.0.2"
 
 [dev-dependencies]
-dylint_testing = "3.0.0"
+dylint_testing.workspace = true

--- a/existing_lints/unwrap_check/Cargo.toml
+++ b/existing_lints/unwrap_check/Cargo.toml
@@ -9,8 +9,8 @@ crate-type = ["cdylib"]
 
 [dependencies]
 clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", tag = "rust-1.77.0"}
-dylint_linting = "2.6.1"
+dylint_linting = "3.0.0"
 if_chain = "1.0.2"
 
 [dev-dependencies]
-dylint_testing = "2.6.1"
+dylint_testing = "3.0.0"

--- a/existing_lints/unwrap_check/ui/unwrap_check.stderr
+++ b/existing_lints/unwrap_check/ui/unwrap_check.stderr
@@ -1,12 +1,11 @@
-error: Use of unwrap().
+warning: Use of unwrap().
   --> $DIR/unwrap_check.rs:11:19
    |
 LL |     let _result = get_result().unwrap();
    |                   ^^^^^^^^^^^^^^^^^^^^^
    |
    = help: Consider implementing proper error handling or using #[allow(unwrap_check)] to suppress the warning.
-   = note: `-D unwrap-check` implied by `-D warnings`
-   = help: to override `-D warnings` add `#[allow(unwrap_check)]`
+   = note: `#[warn(unwrap_check)]` on by default
 
-error: aborting due to 1 previous error
+warning: 1 warning emitted
 


### PR DESCRIPTION
Previous PR missed `cargo-dylint` tag and other dependencies update.