### PR TITLE
Add a lint to warn against using of tokio::time::interval(_at)

### DIFF
--- a/ci/build_nagger.sh
+++ b/ci/build_nagger.sh
@@ -15,8 +15,10 @@ UNWRAP_CHECK_LINT_BIN=libunwrap_check@${RUST_CHANNEL}-x86_64-unknown-linux-gnu.s
 MPSC_BLOCKING_SEND_LINT_BIN=libmpsc_blocking_send@${RUST_CHANNEL}-x86_64-unknown-linux-gnu.so
 LARGE_FUTURES_LINT_BIN=liblarge_futures@${RUST_CHANNEL}-x86_64-unknown-linux-gnu.so
 INDEX_ACCESS_LINT_BIN=libindex_access_check@${RUST_CHANNEL}-x86_64-unknown-linux-gnu.so
+TOKIO_TIME_INTERVAL_BIN=libtokio_time_interval@${RUST_CHANNEL}-x86_64-unknown-linux-gnu.so
 
 cp "${BASE_DIR}/existing_lints/target/${TARGET}/release/${UNWRAP_CHECK_LINT_BIN}" "${BASE_DIR}/dist/"
 cp "${BASE_DIR}/existing_lints/target/${TARGET}/release/${MPSC_BLOCKING_SEND_LINT_BIN}" "${BASE_DIR}/dist/"
 cp "${BASE_DIR}/existing_lints/target/${TARGET}/release/${LARGE_FUTURES_LINT_BIN}" "${BASE_DIR}/dist/"
 cp "${BASE_DIR}/existing_lints/target/${TARGET}/release/${INDEX_ACCESS_LINT_BIN}" "${BASE_DIR}/dist/"
+cp "${BASE_DIR}/existing_lints/target/${TARGET}/release/${TOKIO_TIME_INTERVAL_BIN}" "${BASE_DIR}/dist/"

--- a/existing_lints/Cargo.lock
+++ b/existing_lints/Cargo.lock
@@ -1474,6 +1474,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio_time_interval"
+version = "0.1.0"
+dependencies = [
+ "clippy_utils",
+ "dylint_linting",
+ "dylint_testing",
+ "tokio",
+]
+
+[[package]]
 name = "toml"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/existing_lints/Cargo.toml
+++ b/existing_lints/Cargo.toml
@@ -3,7 +3,8 @@ members = [
     "unwrap_check",
     "mpsc_blocking_send",
     "large_futures",
-    "index_access_check"
+    "index_access_check",
+    "tokio_time_interval"
 ]
 
 [workspace.dependencies]

--- a/existing_lints/tokio_time_interval/Cargo.toml
+++ b/existing_lints/tokio_time_interval/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "tokio_time_interval"
+version = "0.1.0"
+edition = "2021"
+description = "Detect usage of tokio::time::interval"
+
+[[example]]
+name = "ui"
+path = "ui/tokio_time_interval.rs"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", tag = "rust-1.77.0"}
+dylint_linting.workspace = true
+
+[dev-dependencies]
+dylint_testing.workspace = true
+tokio = { version = "1.20.1", features = ["full"]}

--- a/existing_lints/tokio_time_interval/src/lib.rs
+++ b/existing_lints/tokio_time_interval/src/lib.rs
@@ -1,0 +1,38 @@
+// Copyright 2024 Nord Security
+#![feature(rustc_private)]
+#![allow(unused_imports)]
+
+dylint_linting::dylint_library!();
+
+extern crate rustc_ast;
+extern crate rustc_ast_pretty;
+extern crate rustc_data_structures;
+extern crate rustc_errors;
+extern crate rustc_hir;
+extern crate rustc_hir_pretty;
+extern crate rustc_index;
+extern crate rustc_infer;
+extern crate rustc_lexer;
+extern crate rustc_lint;
+extern crate rustc_middle;
+extern crate rustc_parse;
+extern crate rustc_parse_format;
+extern crate rustc_session;
+extern crate rustc_span;
+extern crate rustc_target;
+extern crate rustc_trait_selection;
+
+mod tokio_time_interval;
+
+#[doc(hidden)]
+#[no_mangle]
+pub fn register_lints(_sess: &rustc_session::Session, lint_store: &mut rustc_lint::LintStore) {
+    lint_store.register_lints(&[tokio_time_interval::TOKIO_TIME_INTERVAL]);
+    lint_store.register_late_pass(|_| Box::new(tokio_time_interval::TokioTimeInterval::default()));
+}
+
+// More info on tests https://github.com/trailofbits/dylint/tree/master/utils/testing
+#[test]
+fn ui() {
+    dylint_testing::ui_test_example(env!("CARGO_PKG_NAME"), "ui");
+}

--- a/existing_lints/tokio_time_interval/src/tokio_time_interval.rs
+++ b/existing_lints/tokio_time_interval/src/tokio_time_interval.rs
@@ -1,0 +1,73 @@
+// Copyright 2024 Nord Security
+use clippy_utils::diagnostics::span_lint_and_help;
+use rustc_hir::{Expr, ExprKind, Item, ItemId};
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_middle::ty::TyKind;
+use rustc_middle::ty::VariantDef;
+use rustc_session::{declare_lint, impl_lint_pass};
+use rustc_span::{def_id::DefId, sym};
+use std::collections::HashSet;
+
+// More info on this macro can be found:
+// https://doc.rust-lang.org/nightly/nightly-rustc/rustc_session/macro.declare_lint.html
+// https://rustc-dev-guide.rust-lang.org/diagnostics.html
+declare_lint! {
+    /// **What it does:** Checks for use of blocking tokio::time::interval(_at) calls
+    ///
+    /// **Why is this bad?** This might cause generation of many events if used incorrectly
+    ///
+    /// **Example:**
+    ///
+    /// If there is some periodic action that is triggered by the resulting Interval instance,
+    /// after a long period of sleep it will be triggered 'sleep_duration/interval_period' as fast
+    /// as possible until it is caught up in time to where it should be. Most of the time this is
+    /// not a desired behaviour. This default behaviour can be controlled with the 'set_missed_tick_behavior'
+    /// setter. In libtelio there is already a wrapper that returns correctly configured interval.
+    pub TOKIO_TIME_INTERVAL,
+    Warn,
+    "tokio::time::interval (with the default missed tick behaviour) generates lots of ticks after a sleep"
+}
+
+#[derive(Default)]
+pub struct TokioTimeInterval {}
+
+impl_lint_pass!(TokioTimeInterval => [TOKIO_TIME_INTERVAL]);
+
+impl LateLintPass<'_> for TokioTimeInterval {
+    fn check_expr<'tcx>(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) {
+        if let ExprKind::Call(fun, _args) = &expr.kind {
+            if let ExprKind::Path(rustc_hir::QPath::Resolved(_, path)) = fun.kind {
+                if let Some(path) = path.res.opt_def_id() {
+                    if let Some(syms) = match_def_paths(
+                        cx,
+                        path,
+                        &[
+                            &["tokio", "time", "interval", "interval"],
+                            &["tokio", "time", "interval", "interval_at"],
+                        ],
+                    ) {
+                        let name = syms.join("::");
+                        span_lint_and_help(
+                            cx,
+                            TOKIO_TIME_INTERVAL,
+                            expr.span,
+                            &format!("Use of {name}, this might generate many ticks after a sleep."),
+                            None,
+                            "Consider using wrapper from telio-utils, or set the missed tick behaviour to appropriate value."
+                        );
+                    }
+                }
+            }
+        }
+    }
+}
+
+pub fn match_def_paths<'a>(
+    cx: &LateContext<'_>,
+    path: DefId,
+    syms: &'a [&'a [&str]],
+) -> Option<&'a [&'a str]> {
+    syms.iter()
+        .find(|syms| clippy_utils::match_def_path(cx, path, syms))
+        .map(|syms| *syms)
+}

--- a/existing_lints/tokio_time_interval/ui/tokio_time_interval.rs
+++ b/existing_lints/tokio_time_interval/ui/tokio_time_interval.rs
@@ -1,0 +1,61 @@
+// Copyright 2024 Nord Security
+use std::time::Duration;
+use tokio::time::MissedTickBehavior;
+
+const D: Duration = Duration::from_secs(1);
+
+mod interval {
+    use super::*;
+
+    fn incorrect1() {
+        let _interval = tokio::time::interval(D);
+    }
+
+    fn incorrect2() {
+        use tokio::time::interval;
+        let _interval = interval(D);
+    }
+
+    fn different_function_with_same_name() {
+        fn interval(_: Duration) -> u32 {
+            42
+        }
+        let _interval = interval(D);
+    }
+
+    #[allow(tokio_time_interval)]
+    fn correct() {
+        let mut interval = tokio::time::interval(D);
+        interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    }
+}
+
+mod interval_at {
+    use tokio::time::Instant;
+
+    use super::*;
+
+    fn incorrect1() {
+        let _interval = tokio::time::interval_at(Instant::now(), D);
+    }
+
+    fn incorrect2() {
+        use tokio::time::interval_at;
+        let _interval = interval_at(Instant::now(), D);
+    }
+
+    fn different_function_with_same_name() {
+        fn interval_at(_: Instant, _: Duration) -> u32 {
+            42
+        }
+        let _interval = interval_at(Instant::now(), D);
+    }
+
+    #[allow(tokio_time_interval)]
+    fn correct() {
+        let mut interval = tokio::time::interval_at(Instant::now(), D);
+        interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    }
+}
+
+fn main() {}

--- a/existing_lints/tokio_time_interval/ui/tokio_time_interval.stderr
+++ b/existing_lints/tokio_time_interval/ui/tokio_time_interval.stderr
@@ -1,0 +1,35 @@
+warning: Use of tokio::time::interval::interval, this might generate many ticks after a sleep.
+  --> $DIR/tokio_time_interval.rs:11:25
+   |
+LL |         let _interval = tokio::time::interval(D);
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: Consider using wrapper from telio-utils, or set the missed tick behaviour to appropriate value.
+   = note: `#[warn(tokio_time_interval)]` on by default
+
+warning: Use of tokio::time::interval::interval, this might generate many ticks after a sleep.
+  --> $DIR/tokio_time_interval.rs:16:25
+   |
+LL |         let _interval = interval(D);
+   |                         ^^^^^^^^^^^
+   |
+   = help: Consider using wrapper from telio-utils, or set the missed tick behaviour to appropriate value.
+
+warning: Use of tokio::time::interval::interval_at, this might generate many ticks after a sleep.
+  --> $DIR/tokio_time_interval.rs:39:25
+   |
+LL |         let _interval = tokio::time::interval_at(Instant::now(), D);
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: Consider using wrapper from telio-utils, or set the missed tick behaviour to appropriate value.
+
+warning: Use of tokio::time::interval::interval_at, this might generate many ticks after a sleep.
+  --> $DIR/tokio_time_interval.rs:44:25
+   |
+LL |         let _interval = interval_at(Instant::now(), D);
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: Consider using wrapper from telio-utils, or set the missed tick behaviour to appropriate value.
+
+warning: 4 warnings emitted
+


### PR DESCRIPTION
This function return an interval that can cause huge number of ticks right after a long period of sleep.