### PR TITLE
Add a lint to detect usage of Instant::now from std and tokio

### DIFF
--- a/ci/build_nagger.sh
+++ b/ci/build_nagger.sh
@@ -16,9 +16,11 @@ MPSC_BLOCKING_SEND_LINT_BIN=libmpsc_blocking_send@${RUST_CHANNEL}-x86_64-unknown
 LARGE_FUTURES_LINT_BIN=liblarge_futures@${RUST_CHANNEL}-x86_64-unknown-linux-gnu.so
 INDEX_ACCESS_LINT_BIN=libindex_access_check@${RUST_CHANNEL}-x86_64-unknown-linux-gnu.so
 TOKIO_TIME_INTERVAL_BIN=libtokio_time_interval@${RUST_CHANNEL}-x86_64-unknown-linux-gnu.so
+INSTANT_BIN=libinstant@${RUST_CHANNEL}-x86_64-unknown-linux-gnu.so
 
 cp "${BASE_DIR}/existing_lints/target/${TARGET}/release/${UNWRAP_CHECK_LINT_BIN}" "${BASE_DIR}/dist/"
 cp "${BASE_DIR}/existing_lints/target/${TARGET}/release/${MPSC_BLOCKING_SEND_LINT_BIN}" "${BASE_DIR}/dist/"
 cp "${BASE_DIR}/existing_lints/target/${TARGET}/release/${LARGE_FUTURES_LINT_BIN}" "${BASE_DIR}/dist/"
 cp "${BASE_DIR}/existing_lints/target/${TARGET}/release/${INDEX_ACCESS_LINT_BIN}" "${BASE_DIR}/dist/"
 cp "${BASE_DIR}/existing_lints/target/${TARGET}/release/${TOKIO_TIME_INTERVAL_BIN}" "${BASE_DIR}/dist/"
+cp "${BASE_DIR}/existing_lints/target/${TARGET}/release/${INSTANT_BIN}" "${BASE_DIR}/dist/"

--- a/existing_lints/Cargo.lock
+++ b/existing_lints/Cargo.lock
@@ -887,6 +887,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.0"
+dependencies = [
+ "clippy_utils",
+ "dylint_linting",
+ "dylint_testing",
+ "tokio",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/existing_lints/Cargo.toml
+++ b/existing_lints/Cargo.toml
@@ -4,7 +4,8 @@ members = [
     "mpsc_blocking_send",
     "large_futures",
     "index_access_check",
-    "tokio_time_interval"
+    "tokio_time_interval",
+    "instant"
 ]
 
 [workspace.dependencies]

--- a/existing_lints/instant/Cargo.toml
+++ b/existing_lints/instant/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "instant"
+version = "0.1.0"
+edition = "2021"
+description = "Detect usage of std::time::Instant and tokio::time::Instant"
+
+[[example]]
+name = "ui"
+path = "ui/instant.rs"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", tag = "rust-1.85.0"}
+dylint_linting.workspace = true
+
+[dev-dependencies]
+dylint_testing.workspace = true
+tokio = { version = "1.20.1", features = ["full"]}

--- a/existing_lints/instant/src/instant.rs
+++ b/existing_lints/instant/src/instant.rs
@@ -1,0 +1,92 @@
+// Copyright 2025 Nord Security
+use clippy_utils::diagnostics::span_lint_and_help;
+use rustc_hir::{Expr, ExprKind, Item, ItemId};
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_middle::ty::TyKind;
+use rustc_middle::ty::VariantDef;
+use rustc_session::{declare_lint, impl_lint_pass};
+use rustc_span::{def_id::DefId, sym};
+use std::collections::HashSet;
+
+// More info on this macro can be found:
+// https://doc.rust-lang.org/nightly/nightly-rustc/rustc_session/macro.declare_lint.html
+// https://rustc-dev-guide.rust-lang.org/diagnostics.html
+declare_lint! {
+    /// **What it does:** Checks for use of std::time::Instant and tokio::time::Instant
+    ///
+    /// **Why is this bad?** both types of instant don't take into the account the time spend sleeping / suspended. This can cause reacting to timeouts/timers with the delay equal to the sleep/suspend time.
+    ///
+    /// **Example:**
+    ///
+    /// ```rust
+    /// // Bad
+    /// use std::time::Instant;
+    /// let start = Instant::now();
+    /// // Code that might be interrupted by sleep/suspend
+    /// let elapsed = start.elapsed();
+    /// 
+    /// // Also bad
+    /// use tokio::time::Instant;
+    /// let start = Instant::now();
+    /// // Async code that might be interrupted by sleep/suspend
+    /// let elapsed = start.elapsed();
+    ///
+    /// In libtelio there is already custom implementation of Instant that takes into account time spent in suspend.
+    pub INSTANT,
+    Warn,
+    "default Instant implementations don't take into the account the time spent during suspend"
+}
+
+#[derive(Default)]
+pub struct Instant{}
+
+impl_lint_pass!(Instant => [INSTANT]);
+impl LateLintPass<'_> for Instant {
+    fn check_expr<'tcx>(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) {
+        if let ExprKind::Call(fun, _args) = &expr.kind {
+            if let ExprKind::Path(rustc_hir::QPath::TypeRelative(ty, path_segment)) = fun.kind {
+                if path_segment.ident.as_str() == "now" {
+                    // Get the type information
+                    let ty = cx.typeck_results().node_type(ty.hir_id);
+                    
+                    let std_instant_paths = &[["std", "time", "Instant"].as_slice()];
+                    let tokio_instant_paths = &[["tokio", "time", "instant", "Instant"].as_slice()];
+                    
+                    if let TyKind::Adt(adt_def, _) = ty.kind() {
+                        let def_id = adt_def.did();
+                        
+                        if match_def_paths(cx, def_id, std_instant_paths).is_some() {
+                            span_lint_and_help(
+                                cx,
+                                INSTANT,
+                                expr.span,
+                                "use of `std::time::Instant::now()` detected",
+                                None,
+                                "this Instant implementation doesn't account for system sleep/suspend time, which may lead to inaccurate timing measurements"
+                            );
+                        } else if match_def_paths(cx, def_id, tokio_instant_paths).is_some() {
+                            span_lint_and_help(
+                                cx,
+                                INSTANT,
+                                expr.span,
+                                "use of `tokio::time::Instant::now()` detected",
+                                None,
+                                "this Instant implementation doesn't account for system sleep/suspend time, which may lead to inaccurate timing measurements"
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+pub fn match_def_paths<'a>(
+    cx: &LateContext<'_>,
+    path: DefId,
+    syms: &'a [&'a [&str]],
+) -> Option<&'a [&'a str]> {
+    syms.iter()
+        .find(|syms| clippy_utils::match_def_path(cx, path, syms))
+        .map(|syms| *syms)
+}

--- a/existing_lints/instant/src/lib.rs
+++ b/existing_lints/instant/src/lib.rs
@@ -1,0 +1,38 @@
+// Copyright 2025 Nord Security
+#![feature(rustc_private)]
+#![allow(unused_imports)]
+
+dylint_linting::dylint_library!();
+
+extern crate rustc_ast;
+extern crate rustc_ast_pretty;
+extern crate rustc_data_structures;
+extern crate rustc_errors;
+extern crate rustc_hir;
+extern crate rustc_hir_pretty;
+extern crate rustc_index;
+extern crate rustc_infer;
+extern crate rustc_lexer;
+extern crate rustc_lint;
+extern crate rustc_middle;
+extern crate rustc_parse;
+extern crate rustc_parse_format;
+extern crate rustc_session;
+extern crate rustc_span;
+extern crate rustc_target;
+extern crate rustc_trait_selection;
+
+mod instant;
+
+#[doc(hidden)]
+#[no_mangle]
+pub fn register_lints(_sess: &rustc_session::Session, lint_store: &mut rustc_lint::LintStore) {
+    lint_store.register_lints(&[instant::INSTANT]);
+    lint_store.register_late_pass(|_| Box::new(instant::Instant::default()));
+}
+
+// More info on tests https://github.com/trailofbits/dylint/tree/master/utils/testing
+#[test]
+fn ui() {
+    dylint_testing::ui_test_example(env!("CARGO_PKG_NAME"), "ui");
+}

--- a/existing_lints/instant/ui/instant.rs
+++ b/existing_lints/instant/ui/instant.rs
@@ -1,0 +1,38 @@
+// Copyright 2025 Nord Security
+
+fn incorrect_std_1() {
+    let _instant1 = std::time::Instant::now();
+}
+
+fn incorrect_std_2() {
+    use std::time::Instant;
+    let _instant2 = Instant::now();
+}
+
+fn incorrect_tokio_1() {
+    let _instant3 = tokio::time::Instant::now();
+}
+
+fn incorrect_tokio_2() {
+    use tokio::time::Instant;
+    let _instant4 = Instant::now();
+}
+
+
+#[allow(instant)]
+fn correct_std_1() {    
+    let _instant5 = std::time::Instant::now();
+
+    use std::time::Instant;
+    let _instant6 = Instant::now();
+}
+
+#[allow(instant)]
+fn correct_tokio_1() {
+    let _instant7= tokio::time::Instant::now();
+    
+    use tokio::time::Instant;
+    let _instant8 = Instant::now();
+}
+
+fn main() {}

--- a/existing_lints/instant/ui/instant.stderr
+++ b/existing_lints/instant/ui/instant.stderr
@@ -1,0 +1,35 @@
+warning: use of `std::time::Instant::now()` detected
+  --> $DIR/instant.rs:4:21
+   |
+LL |     let _instant1 = std::time::Instant::now();
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: this Instant implementation doesn't account for system sleep/suspend time, which may lead to inaccurate timing measurements
+   = note: `#[warn(instant)]` on by default
+
+warning: use of `std::time::Instant::now()` detected
+  --> $DIR/instant.rs:9:21
+   |
+LL |     let _instant2 = Instant::now();
+   |                     ^^^^^^^^^^^^^^
+   |
+   = help: this Instant implementation doesn't account for system sleep/suspend time, which may lead to inaccurate timing measurements
+
+warning: use of `tokio::time::Instant::now()` detected
+  --> $DIR/instant.rs:13:21
+   |
+LL |     let _instant3 = tokio::time::Instant::now();
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: this Instant implementation doesn't account for system sleep/suspend time, which may lead to inaccurate timing measurements
+
+warning: use of `tokio::time::Instant::now()` detected
+  --> $DIR/instant.rs:18:21
+   |
+LL |     let _instant4 = Instant::now();
+   |                     ^^^^^^^^^^^^^^
+   |
+   = help: this Instant implementation doesn't account for system sleep/suspend time, which may lead to inaccurate timing measurements
+
+warning: 4 warnings emitted
+


### PR DESCRIPTION
`Instant` is problematic, because it doesn't track the time spent in suspend.